### PR TITLE
close #4: support denops lazy load

### DIFF
--- a/bundler/src/constants.rs
+++ b/bundler/src/constants.rs
@@ -17,6 +17,7 @@ pub mod dir {
     pub static EVENTS: &str = "events";
     pub static FILETYPES: &str = "filetypes";
     pub static COMMANDS: &str = "commands";
+    pub static RTP: &str = "rtp";
 }
 
 pub mod file {
@@ -26,5 +27,6 @@ pub mod file {
     pub static FILETYPES: &str = "filetype_keys";
     pub static COMMANDS: &str = "command_keys";
     pub static LAZYS: &str = "lazys";
+    pub static DENOPS: &str = "denops";
     pub static PAYLOAD: &str = "payload";
 }

--- a/bundler/src/content/config.rs
+++ b/bundler/src/content/config.rs
@@ -51,10 +51,13 @@ pub struct LoadingOptions<'a> {
     pub filetypes: HashMap<&'a str, Vec<&'a str>>,
     pub commands: HashMap<&'a str, Vec<&'a str>>,
     pub lazys: Vec<&'a str>,
+    pub denops_clients: Vec<&'a str>,
 }
 
 #[derive(Debug)]
 pub struct Specs<'a> {
+    /// key is package (e.g. `/nix/store/...`), value is id.
+    pub id_map: HashMap<&'a str, &'a str>,
     pub start_plugins: Vec<StartPlugin<'a>>,
     pub opt_plugins: Vec<OptPlugin<'a>>,
     pub bundles: Vec<Bundle<'a>>,

--- a/bundler/src/content/unpack.rs
+++ b/bundler/src/content/unpack.rs
@@ -261,6 +261,9 @@ fn unpack_opt_plugin_load_options<'a>(
                 if cfg.lazy {
                     load_opt_acc.lazys.push(id);
                 }
+                if cfg.use_denops {
+                    load_opt_acc.denops_clients.push(id);
+                }
                 unpack_opt_plugin_load_options(
                     config::LoadingOptions {
                         depends,
@@ -402,6 +405,7 @@ pub fn unpack<'a>(payload: &'a payload::Payload) -> config::Specs<'a> {
     let load_opt = unpack_bundle_load_options(load_opt, &id_map, &payload.cfg.bundles);
 
     config::Specs {
+        id_map,
         start_plugins,
         opt_plugins,
         bundles,
@@ -697,6 +701,7 @@ mod tests {
             filetypes: HashMap::from([]),
             commands: HashMap::from([]),
             lazys: vec![],
+            denops_clients: vec![],
         };
 
         let act = super::unpack_opt_plugin_load_options(
@@ -730,6 +735,7 @@ mod tests {
             filetypes: vec![filetype_name.to_string()],
             commands: vec![command_name.to_string()],
             lazy: true,
+            use_denops: true,
             ..Default::default()
         });
         let exp = config::LoadingOptions {
@@ -740,6 +746,7 @@ mod tests {
             filetypes: HashMap::from([(filetype_name, vec![name1])]),
             commands: HashMap::from([(command_name, vec![name1])]),
             lazys: vec![name1],
+            denops_clients: vec![name1],
         };
 
         let act = super::unpack_opt_plugin_load_options(
@@ -792,6 +799,7 @@ mod tests {
             filetypes: HashMap::from([(filetype_name, vec![bundle_name])]),
             commands: HashMap::from([(command_name, vec![bundle_name])]),
             lazys: vec![bundle_name],
+            denops_clients: vec![],
         };
 
         let act =

--- a/bundler/src/lua.rs
+++ b/bundler/src/lua.rs
@@ -1,6 +1,16 @@
-/// rust list to lua table.
+/// rust list to lua table (vector).
 pub fn to_lua_table(v: &[&str]) -> String {
     let wrap = v.iter().map(|s| format!("\"{}\"", s)).collect::<Vec<_>>();
+    ["{", wrap.join(",").as_ref(), "}"].join("")
+}
+
+/// rust list to lua table (dictionary).
+pub fn to_lua_flag_table(v: &[&str], default: bool) -> String {
+    let default = if default { "true" } else { "false" };
+    let wrap = v
+        .iter()
+        .map(|s| format!("[\"{}\"]={}", s, default))
+        .collect::<Vec<_>>();
     ["{", wrap.join(",").as_ref(), "}"].join("")
 }
 
@@ -16,6 +26,20 @@ mod tests {
     )]
     fn test_to_lua_table(arg: Vec<&str>, exp: String) {
         let act = to_lua_table(&arg);
+
+        assert_eq!(exp, act);
+    }
+
+    #[rstest(arg, default, exp,
+        case(vec![], true, r#"{}"#),
+        case(vec![], false, r#"{}"#),
+        case(vec!["a"],true, r#"{["a"]=true}"#),
+        case(vec!["a"],false, r#"{["a"]=false}"#),
+        case(vec!["a","b"],true, r#"{["a"]=true,["b"]=true}"#),
+        case(vec!["a","b"],false, r#"{["a"]=false,["b"]=false}"#),
+    )]
+    fn test_to_lua_flag_table(arg: Vec<&str>, default: bool, exp: String) {
+        let act = to_lua_flag_table(&arg, default);
 
         assert_eq!(exp, act);
     }

--- a/bundler/src/main.rs
+++ b/bundler/src/main.rs
@@ -28,9 +28,9 @@ fn main() {
 
     let input_json_text = fs::read_to_string(input_json_path).unwrap();
     let payload = serde_json::from_str::<Payload>(&input_json_text).unwrap();
-    let pack = unpack(&payload);
+    let specs = unpack(&payload);
 
-    bundle(output_dir, &input_json_path, pack).unwrap();
+    bundle(output_dir, &input_json_path, specs).unwrap();
 
     log::info!("bundle completed");
 }

--- a/bundler/src/payload/operation.rs
+++ b/bundler/src/payload/operation.rs
@@ -58,6 +58,7 @@ mod tests {
                 filetypes: vec![String::from("filled-filetype")],
                 commands: vec![String::from("filled-command")],
                 lazy: true,
+                use_denops: true,
             })
         }
 
@@ -86,6 +87,7 @@ mod tests {
                 filetypes: vec![String::from("filled-detail-filetype")],
                 commands: vec![String::from("filled-detail-command")],
                 lazy: false,
+                use_denops: true,
             })
         }
 

--- a/bundler/src/payload/opt.rs
+++ b/bundler/src/payload/opt.rs
@@ -24,4 +24,5 @@ pub struct PluginConfig {
     pub filetypes: Vec<String>,
     pub commands: Vec<String>,
     pub lazy: bool,
+    pub use_denops: bool,
 }

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -121,6 +121,7 @@ in {
                 default = [ ];
               };
               lazy = mkEnableOption "lazy";
+              useDenops = mkEnableOption "useDenops";
             };
           };
           bundleConfig = types.submodule {
@@ -180,6 +181,7 @@ in {
                 default = [ ];
               };
               lazy = mkEnableOption "lazy";
+              useDenops = mkEnableOption "useDenops";
             };
           };
         in {


### PR DESCRIPTION
Usage

```nix
{ plugin = ddc-vim; depends = [ denops-vim ]; useDenops = true; }
```